### PR TITLE
#13 add missing holiday on 8 May 2025 in Berlin

### DIFF
--- a/src/Service/Holidays.php
+++ b/src/Service/Holidays.php
@@ -219,6 +219,11 @@ class Holidays
             $days['2017-10-31'] = "500. Jahrestag der Reformation";
             ksort($days);
         }
+        //special single holiday in Berlin
+        if ($year == 2025 AND $region == 'DE-BE') {
+            $days['2025-05-08'] = "80. Jahrestag der Befreiung vom Nationalsozialismus";
+            ksort($days);
+        }
         return $days;
     }
 


### PR DESCRIPTION
There is a missing public holiday in the API for Berlin on 8 May 2025. Berlin declared 8 May 2025 a one-time public [holiday](https://www.berlin.de/tourismus/infos/1887651-1721039-feiertage-schulferien.html) to memorialise the 80th anniversary of the end of World War II in Europe ("Tag der Befreiung").